### PR TITLE
Fix/mail execution

### DIFF
--- a/src/main/java/io/kestra/plugin/notifications/ExecutionInterface.java
+++ b/src/main/java/io/kestra/plugin/notifications/ExecutionInterface.java
@@ -8,7 +8,8 @@ import java.util.Map;
 public interface ExecutionInterface {
     @Schema(
         title = "The execution id to use",
-        description = "Default is the current execution"
+        description = "Default is the current execution, " +
+            "change it to {{ trigger.executionId }} if you use this task with a Flow trigger to use the original execution."
     )
     @PluginProperty(dynamic = true)
     String getExecutionId();

--- a/src/main/java/io/kestra/plugin/notifications/mail/MailExecution.java
+++ b/src/main/java/io/kestra/plugin/notifications/mail/MailExecution.java
@@ -41,6 +41,7 @@ import java.util.Map;
                     port: 465
                     username: "{{ secret('EMAIL_USERNAME') }}"
                     password: "{{ secret('EMAIL_PASSWORD') }}"
+                    executionId: "{{ trigger.executionId }}"
 
                 triggers:
                   - id: failed_prod_workflows

--- a/src/main/java/io/kestra/plugin/notifications/sendgrid/SendGridMailExecution.java
+++ b/src/main/java/io/kestra/plugin/notifications/sendgrid/SendGridMailExecution.java
@@ -38,6 +38,7 @@ import java.util.Map;
                     from: hello@kestra.io
                     subject: "The workflow execution {{trigger.executionId}} failed for the flow {{trigger.flowId}} in the namespace {{trigger.namespace}}"
                     sendgridApiKey: "{{ secret('SENDGRID_API_KEY') }}"
+                    executionId: "{{ trigger.executionId }}"
 
                 triggers:
                   - id: failed_prod_workflows

--- a/src/main/java/io/kestra/plugin/notifications/sentry/SentryExecution.java
+++ b/src/main/java/io/kestra/plugin/notifications/sentry/SentryExecution.java
@@ -38,6 +38,7 @@ import java.util.Map;
                     transaction: "/execution/id/{{ trigger.executionId} }"
                     dsn: "{{ secret('SENTRY_DSN') }}" # format: https://xxx@xxx.ingest.sentry.io/xxx
                     level: ERROR
+                    executionId: "{{ trigger.executionId }}"
 
                 triggers:
                   - id: failed_prod_workflows

--- a/src/main/java/io/kestra/plugin/notifications/services/ExecutionService.java
+++ b/src/main/java/io/kestra/plugin/notifications/services/ExecutionService.java
@@ -36,6 +36,9 @@ public class ExecutionService {
         var flowVars = (Map<String, String>) runContext.getVariables().get("flow");
         var executionVars = (Map<String, String>) runContext.getVariables().get("execution");
         var isCurrentExecution = executionRendererId.equals(executionVars.get("id"));
+        if (isCurrentExecution) {
+            runContext.logger().info("Loading execution data for the current execution (this should only be done in a listener).");
+        }
 
         return retryInstance.run(
             NoSuchElementException.class,

--- a/src/main/java/io/kestra/plugin/notifications/teams/TeamsExecution.java
+++ b/src/main/java/io/kestra/plugin/notifications/teams/TeamsExecution.java
@@ -40,6 +40,7 @@ import java.util.Map;
                     type: io.kestra.plugin.notifications.teams.TeamsExecution
                     url: "{{ secret('TEAMS_WEBHOOK') }}" # format: https://microsoft.webhook.office.com/webhook/xyz
                     activityTitle: "Kestra Teams notification"
+                    executionId: "{{ trigger.executionId }}"
 
                 triggers:
                   - id: failed_prod_workflows

--- a/src/main/java/io/kestra/plugin/notifications/telegram/TelegramExecution.java
+++ b/src/main/java/io/kestra/plugin/notifications/telegram/TelegramExecution.java
@@ -36,6 +36,7 @@ import java.util.Map;
                     type: io.kestra.plugin.notifications.telegram.TelegramExecution
                     token: "{{ secret('TELEGRAM_TOKEN') }}" # format: 6090305634:xyz
                     channel: "2072728690"
+                    executionId: "{{ trigger.executionId }}"
 
                 triggers:
                   - id: failed_prod_workflows


### PR DESCRIPTION
Add the usage of `{{ trigger.executionId }}` for all *Execution tasks as the example use a trigger.

Document the usage of the trigger execution ID on the `executionId` property.

Don't wait for a execution to be terminated if it's the current execution. This is a workaround, fow now as it needs more discussion.

Fixes #101
Fixes #98