### PR TITLE
docs: fix typo for Succeded

### DIFF
--- a/src/main/java/io/kestra/plugin/notifications/discord/DiscordIncomingWebhook.java
+++ b/src/main/java/io/kestra/plugin/notifications/discord/DiscordIncomingWebhook.java
@@ -80,7 +80,7 @@ import java.net.URI;
                                 "color": 16777215
                                 "description": "Namespace: dev\nFlow ID: discord\nExecution ID: 1p0JVFz24ZVLSK8iJN6hfs\nExecution Status: SUCCESS\n\n[Link to the Execution page](http://localhost:8080/ui/executions/dev/discord/1p0JVFz24ZVLSK8iJN6hfs)",
                                 "footer": {
-                                    "text": "Succeded after 00:00:00.385"
+                                    "text": "Succeeded after 00:00:00.385"
                                 }
                             }
                         ]

--- a/src/main/resources/discord-template.peb
+++ b/src/main/resources/discord-template.peb
@@ -37,7 +37,7 @@
           {
                 "description": "Namespace: {{execution.namespace}}\nFlow ID: {{execution.flowId}}\nExecution ID: {{execution.id}}\nExecution Status: {{execution.state.current}} {% if link is defined %}\n\n[Link to the Execution page]({{link}}){% endif %}",
                 "footer": {
-                    "text": "{% if firstFailed == false %}Succeded{% else %}Failed on task `{{firstFailed.taskId}}`{% endif %} after {{duration}}"
+                    "text": "{% if firstFailed == false %}Succeeded{% else %}Failed on task `{{firstFailed.taskId}}`{% endif %} after {{duration}}"
                 }
           }
         ]

--- a/src/main/resources/google-chat-template.peb
+++ b/src/main/resources/google-chat-template.peb
@@ -1,3 +1,3 @@
 {
-    "text": "Kestra Google notification: Namespace {{execution.namespace}}, Flow ID {{execution.flowId}}, Execution ID {{execution.id}}, Execution Status {{execution.state.current}}. *<{{link}}|[{{execution.namespace}}] {{execution.flowId}} ➛ {{execution.state.current}}>*\n> {% if firstFailed == false %}Succeded{% else %}Failed on task `{{firstFailed.taskId}}`{% endif %} after {{duration}}"
+    "text": "Kestra Google notification: Namespace {{execution.namespace}}, Flow ID {{execution.flowId}}, Execution ID {{execution.id}}, Execution Status {{execution.state.current}}. *<{{link}}|[{{execution.namespace}}] {{execution.flowId}} ➛ {{execution.state.current}}>*\n> {% if firstFailed == false %}Succeeded{% else %}Failed on task `{{firstFailed.taskId}}`{% endif %} after {{duration}}"
 }

--- a/src/main/resources/mail-template.hbs.peb
+++ b/src/main/resources/mail-template.hbs.peb
@@ -136,7 +136,7 @@
                                         </p>
                                         {% endif %}
                                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">
-                                            {% if firstFailed == false %}Succeded{% else %}Failed on task `{{firstFailed.taskId}}`{% endif %} after {{duration}}
+                                            {% if firstFailed == false %}Succeeded{% else %}Failed on task `{{firstFailed.taskId}}`{% endif %} after {{duration}}
                                         </p>
                                         {% if link is defined %}
                                         <table border="0" cellpadding="0" cellspacing="0" class="btn btn-primary"

--- a/src/main/resources/opsgenie-template.peb
+++ b/src/main/resources/opsgenie-template.peb
@@ -43,5 +43,5 @@
             "Execution Status": "{{execution.state.current}}"
         },
     {% endif %}
-    "description": "*<{{link}}|[{{execution.namespace}}] {{execution.flowId}} ➛ {{execution.state.current}}>*\n> {% if firstFailed == false %}Succeded{% else %}Failed on task `{{firstFailed.taskId}}`{% endif %} after {{duration}}"
+    "description": "*<{{link}}|[{{execution.namespace}}] {{execution.flowId}} ➛ {{execution.state.current}}>*\n> {% if firstFailed == false %}Succeeded{% else %}Failed on task `{{firstFailed.taskId}}`{% endif %} after {{duration}}"
 }

--- a/src/main/resources/pagerduty-template.peb
+++ b/src/main/resources/pagerduty-template.peb
@@ -26,6 +26,6 @@
         "links": [
           {
                 "href": "*<{{link}}|[{{execution.namespace}}] {{execution.flowId}} ➛ {{execution.state.current}}>*\n>",
-                "text": "{% if firstFailed == false %}Succeded{% else %}Failed on task `{{firstFailed.taskId}}`{% endif %} after {{duration}}"
+                "text": "{% if firstFailed == false %}Succeeded{% else %}Failed on task `{{firstFailed.taskId}}`{% endif %} after {{duration}}"
           }]
 }

--- a/src/main/resources/sendgrid-mail-template.hbs.peb
+++ b/src/main/resources/sendgrid-mail-template.hbs.peb
@@ -136,7 +136,7 @@
                                         </p>
                                         {% endif %}
                                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">
-                                            {% if firstFailed == false %}Succeded{% else %}Failed on task `{{firstFailed.taskId}}`{% endif %} after {{duration}}
+                                            {% if firstFailed == false %}Succeeded{% else %}Failed on task `{{firstFailed.taskId}}`{% endif %} after {{duration}}
                                         </p>
                                         {% if link is defined %}
                                         <table border="0" cellpadding="0" cellspacing="0" class="btn btn-primary"

--- a/src/main/resources/slack-template.peb
+++ b/src/main/resources/slack-template.peb
@@ -23,7 +23,7 @@
 			"type": "section",
 			"text": {
 				"type": "mrkdwn",
-				"text": "{{ title(link, execution) }}\n> {% if firstFailed == false %}Succeded{% else %}Failed on task `{{firstFailed.taskId}}`{% endif %} after {{duration}}"
+				"text": "{{ title(link, execution) }}\n> {% if firstFailed == false %}Succeeded{% else %}Failed on task `{{firstFailed.taskId}}`{% endif %} after {{duration}}"
 			}
 			{% if link is defined %},
 			"accessory": {

--- a/src/main/resources/twilio-template.peb
+++ b/src/main/resources/twilio-template.peb
@@ -5,5 +5,5 @@
     {% if tag is defined %}
         "tag": "{{tag}}",
     {% endif %}
-    "body": "Namespace {{execution.namespace}}, Flow ID {{execution.flowId}}, Execution ID {{execution.id}}, Execution Status {{execution.state.current}}. *<{{link}}|[{{execution.namespace}}] {{execution.flowId}} ➛ {{execution.state.current}}>*\n> {% if firstFailed == false %}Succeded{% else %}Failed on task `{{firstFailed.taskId}}`{% endif %} after {{duration}}"
+    "body": "Namespace {{execution.namespace}}, Flow ID {{execution.flowId}}, Execution ID {{execution.id}}, Execution Status {{execution.state.current}}. *<{{link}}|[{{execution.namespace}}] {{execution.flowId}} ➛ {{execution.state.current}}>*\n> {% if firstFailed == false %}Succeeded{% else %}Failed on task `{{firstFailed.taskId}}`{% endif %} after {{duration}}"
 }

--- a/src/main/resources/whatsapp-template.peb
+++ b/src/main/resources/whatsapp-template.peb
@@ -24,7 +24,7 @@
         "Flow ID {{execution.flowId}}",
         "Execution ID {{execution.id}}",
         "Execution Status {{execution.state.current}}",
-        "*<{{link}}|[{{execution.namespace}}] {{execution.flowId}} ➛ {{execution.state.current}}>*\n> {% if firstFailed == false %}Succeded{% else %}Failed on task `{{firstFailed.taskId}}`{% endif %} after {{duration}}"
+        "*<{{link}}|[{{execution.namespace}}] {{execution.flowId}} ➛ {{execution.state.current}}>*\n> {% if firstFailed == false %}Succeeded{% else %}Failed on task `{{firstFailed.taskId}}`{% endif %} after {{duration}}"
         ]
     },
     "type": "text"


### PR DESCRIPTION
### What changes are being made and why?

Correcting the typos for Succeded to satisfy the codespell check used in SchemaStore, see [https://github.com/kestra-io/kestra/issues/4653](https://github.com/kestra-io/kestra/issues/4653) for further details