### PR TITLE
fix: remove htmlTextContent property from MailExecution

### DIFF
--- a/src/main/java/io/kestra/plugin/notifications/mail/MailExecution.java
+++ b/src/main/java/io/kestra/plugin/notifications/mail/MailExecution.java
@@ -65,6 +65,10 @@ public class MailExecution extends MailTemplate implements ExecutionInterface {
     private Property<Map<String, Object>> customFields;
     private Property<String> customMessage;
 
+    @Getter(AccessLevel.NONE)
+    @Setter(AccessLevel.PUBLIC)
+    protected Property<String> htmlTextContent;
+
     @Override
     public VoidOutput run(RunContext runContext) throws Exception {
         this.templateUri = Property.of("mail-template.hbs.peb");


### PR DESCRIPTION
make this removal retrocompatible
add setter but remove getter to avoid appearance in documentation

#196
