### PR TITLE
Add parse_mode option to io.kestra.plugin.notifications.telegram.Tele…

### DIFF
--- a/src/main/java/io/kestra/plugin/notifications/telegram/TelegramBotApiService.java
+++ b/src/main/java/io/kestra/plugin/notifications/telegram/TelegramBotApiService.java
@@ -13,9 +13,9 @@ import java.util.Objects;
 
 public class TelegramBotApiService {
 
-    public static void send(HttpClient client, String destinationId, String apiToken, String message, String url, HttpRequest.HttpRequestBuilder requestBuilder) throws ErrorSendingMessageException {
+    public static void send(HttpClient client, String destinationId, String apiToken, String message, String url, HttpRequest.HttpRequestBuilder requestBuilder, String parseMode) throws ErrorSendingMessageException {
 
-        TelegramMessage payload = new TelegramMessage(destinationId, message);
+        TelegramMessage payload = new TelegramMessage(destinationId, message, parseMode);
 
         String uri = url+ "/bot{token}/sendMessage".replace("{token}", apiToken);
 
@@ -47,7 +47,7 @@ public class TelegramBotApiService {
     public record TelegramBotApiResponse(boolean ok, TelegramMessage result) {
     }
 
-    public record TelegramMessage(String chat_id, String text) {
+    public record TelegramMessage(String chat_id, String text, String parse_mode) {
     }
 
     public static class ErrorSendingMessageException extends Exception {

--- a/src/main/java/io/kestra/plugin/notifications/telegram/TelegramSend.java
+++ b/src/main/java/io/kestra/plugin/notifications/telegram/TelegramSend.java
@@ -7,15 +7,13 @@ import io.kestra.core.models.tasks.VoidOutput;
 import io.kestra.core.runners.RunContext;
 import io.kestra.plugin.notifications.AbstractHttpOptionsTask;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
-
-import java.net.http.HttpHeaders;
-import java.util.Map;
 
 @SuperBuilder
 @ToString
@@ -36,6 +34,9 @@ public class TelegramSend extends AbstractHttpOptionsTask {
     @Schema(title = "Message payload")
     protected Property<String> payload;
 
+    @Schema(title = "Telegram Bot parse-Mode", description = "Optional text formatting mode for Telegram messages. Supported values: HTML, Markdown, MarkdownV2.", example = "HTML")
+    @Nullable
+    protected Property<String> parseMode;
     @Schema(
         title = "Only to be used when testing locally"
     )
@@ -51,7 +52,8 @@ public class TelegramSend extends AbstractHttpOptionsTask {
             String destination = runContext.render(this.channel).as(String.class).orElseThrow();
             String apiToken = runContext.render(this.token).as(String.class).orElseThrow();
             String rendered = runContext.render(payload).as(String.class).orElseThrow();
-            TelegramBotApiService.send(httpClient, destination, apiToken, rendered, url, requestBuilder);
+            String parseMode = runContext.render(this.parseMode).as(String.class).orElse(null);
+            TelegramBotApiService.send(httpClient, destination, apiToken, rendered, url, requestBuilder, parseMode);
         }
 
         return null;

--- a/src/main/java/io/kestra/plugin/notifications/telegram/TelegramSend.java
+++ b/src/main/java/io/kestra/plugin/notifications/telegram/TelegramSend.java
@@ -36,7 +36,7 @@ public class TelegramSend extends AbstractHttpOptionsTask {
 
     @Schema(title = "Telegram Bot parse-Mode", description = "Optional text formatting mode for Telegram messages. Supported values: HTML, Markdown, MarkdownV2.", example = "HTML")
     @Nullable
-    protected Property<String> parseMode;
+    protected Property<ParseMode> parseMode;
     @Schema(
         title = "Only to be used when testing locally"
     )
@@ -52,10 +52,25 @@ public class TelegramSend extends AbstractHttpOptionsTask {
             String destination = runContext.render(this.channel).as(String.class).orElseThrow();
             String apiToken = runContext.render(this.token).as(String.class).orElseThrow();
             String rendered = runContext.render(payload).as(String.class).orElseThrow();
-            String parseMode = runContext.render(this.parseMode).as(String.class).orElse(null);
+            String parseMode = runContext.render(this.parseMode).as(ParseMode.class).map(ParseMode::getValue).orElse(null);
             TelegramBotApiService.send(httpClient, destination, apiToken, rendered, url, requestBuilder, parseMode);
         }
 
         return null;
+    }
+
+    public enum ParseMode {
+        HTML("HTML"),
+        MARKDOWNV2("MarkdownV2");
+
+        private final String value;
+
+        ParseMode(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
     }
 }

--- a/src/test/java/io/kestra/plugin/notifications/telegram/TelegramSendTest.java
+++ b/src/test/java/io/kestra/plugin/notifications/telegram/TelegramSendTest.java
@@ -46,7 +46,33 @@ class TelegramSendTest {
         task.run(runContext);
 
         assertThat(FakeTelegramController.token, containsString(token));
-        assertThat(FakeTelegramController.message, equalToObject(new TelegramBotApiService.TelegramMessage(channel, message)));
+        assertThat(FakeTelegramController.message, equalToObject(new TelegramBotApiService.TelegramMessage(channel, message, null)));
+
+    }
+
+    @Test
+    void run_withParseModeAsHTML_shouldSendTelegram() throws Exception {
+        RunContext runContext = runContextFactory.of();
+
+        EmbeddedServer embeddedServer = applicationContext.getBean(EmbeddedServer.class);
+        embeddedServer.start();
+
+        String message = "Hello";
+        String channel = "channel";
+        String token = "token";
+        String parseMode = "HTML";
+
+        TelegramSend task = TelegramSend.builder()
+            .endpointOverride(Property.of(embeddedServer.getURL().toString()))
+            .token(Property.of(token))
+            .channel(Property.of(channel))
+            .payload(Property.of(message))
+            .parseMode(Property.of(parseMode))
+            .build();
+        task.run(runContext);
+
+        assertThat(FakeTelegramController.token, containsString(token));
+        assertThat(FakeTelegramController.message, equalToObject(new TelegramBotApiService.TelegramMessage(channel, message, parseMode)));
 
     }
 }

--- a/src/test/java/io/kestra/plugin/notifications/telegram/TelegramSendTest.java
+++ b/src/test/java/io/kestra/plugin/notifications/telegram/TelegramSendTest.java
@@ -60,14 +60,40 @@ class TelegramSendTest {
         String message = "Hello";
         String channel = "channel";
         String token = "token";
-        String parseMode = "HTML";
+        String parseMode = TelegramSend.ParseMode.HTML.getValue();
 
         TelegramSend task = TelegramSend.builder()
             .endpointOverride(Property.of(embeddedServer.getURL().toString()))
             .token(Property.of(token))
             .channel(Property.of(channel))
             .payload(Property.of(message))
-            .parseMode(Property.of(parseMode))
+            .parseMode(Property.of(TelegramSend.ParseMode.HTML))
+            .build();
+        task.run(runContext);
+
+        assertThat(FakeTelegramController.token, containsString(token));
+        assertThat(FakeTelegramController.message, equalToObject(new TelegramBotApiService.TelegramMessage(channel, message, parseMode)));
+
+    }
+
+    @Test
+    void run_withParseModeAsMarktDownV2_shouldSendTelegram() throws Exception {
+        RunContext runContext = runContextFactory.of();
+
+        EmbeddedServer embeddedServer = applicationContext.getBean(EmbeddedServer.class);
+        embeddedServer.start();
+
+        String message = "Hello";
+        String channel = "channel";
+        String token = "token";
+        String parseMode = TelegramSend.ParseMode.MARKDOWNV2.getValue();
+
+        TelegramSend task = TelegramSend.builder()
+            .endpointOverride(Property.of(embeddedServer.getURL().toString()))
+            .token(Property.of(token))
+            .channel(Property.of(channel))
+            .payload(Property.of(message))
+            .parseMode(Property.of(TelegramSend.ParseMode.MARKDOWNV2))
             .build();
         task.run(runContext);
 


### PR DESCRIPTION
…gramSend #159

<!-- Thanks for submitting a Pull Request to kestra. To help us review your contribution, please follow the guidelines below:


- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "close" to automatically close an issue. For example, `close #1234` will close issue #1234. -->

### What changes are being made and why?
<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->
- https://github.com/kestra-io/plugin-notifications/issues/159 -
- Added the optional parse_mode field for Telegram messages. When not provided (defaults to null), the message is sent in plain text.

---
fixes #159 

