### PR TITLE
fix(*): execution service failing for RUNNING task

### DIFF
--- a/src/main/java/io/kestra/plugin/notifications/discord/DiscordExecution.java
+++ b/src/main/java/io/kestra/plugin/notifications/discord/DiscordExecution.java
@@ -68,8 +68,9 @@ public class DiscordExecution extends DiscordTemplate implements ExecutionInterf
 
     @Override
     public VoidOutput run(RunContext runContext) throws Exception {
-        this.templateUri = Property.of("discord-template.peb");
-        this.templateRenderMap = Property.of(ExecutionService.executionMap(runContext, this));
+
+        this.templateUri = Property.ofValue("discord-template.peb");
+        this.templateRenderMap = Property.ofValue(ExecutionService.executionMap(runContext, this));
 
         return super.run(runContext);
     }

--- a/src/main/java/io/kestra/plugin/notifications/discord/DiscordTemplate.java
+++ b/src/main/java/io/kestra/plugin/notifications/discord/DiscordTemplate.java
@@ -67,7 +67,7 @@ public abstract class DiscordTemplate extends DiscordIncomingWebhook {
         Map<String, Object> mainMap = new HashMap<>();
 
         final Optional<String> renderedUri = runContext.render(this.templateUri).as(String.class);
-        
+
         if (renderedUri.isPresent()) {
             String template = IOUtils.toString(
                 Objects.requireNonNull(this.getClass()
@@ -77,8 +77,8 @@ public abstract class DiscordTemplate extends DiscordIncomingWebhook {
                 StandardCharsets.UTF_8
             );
 
-            String render = runContext.render(template, templateRenderMap != null ? 
-                runContext.render(templateRenderMap).asMap(String.class, Object.class) : 
+            String render = runContext.render(template, templateRenderMap != null ?
+                runContext.render(templateRenderMap).asMap(String.class, Object.class) :
                 Map.of());
             mainMap = (Map<String, Object>) JacksonMapper.ofJson().readValue(render, Object.class);
         }
@@ -116,7 +116,7 @@ public abstract class DiscordTemplate extends DiscordIncomingWebhook {
             mainMap.put("content", runContext.render(this.content).as(String.class).get());
         }
 
-        this.payload = Property.of(JacksonMapper.ofJson().writeValueAsString(mainMap));
+        this.payload = Property.ofValue(JacksonMapper.ofJson().writeValueAsString(mainMap));
 
         return super.run(runContext);
     }

--- a/src/main/java/io/kestra/plugin/notifications/services/ExecutionService.java
+++ b/src/main/java/io/kestra/plugin/notifications/services/ExecutionService.java
@@ -35,8 +35,7 @@ public class ExecutionService {
         var flowTriggerExecutionState = getOptionalFlowTriggerExecutionState(runContext);
 
         var flowVars = (Map<String, String>) runContext.getVariables().get("flow");
-        var executionVars = (Map<String, String>) runContext.getVariables().get("execution");
-        var isCurrentExecution = executionRendererId.equals(executionVars.get("id"));
+        var isCurrentExecution = isCurrentExecution(runContext, executionRendererId);
         if (isCurrentExecution) {
             runContext.logger().info("Loading execution data for the current execution.");
         }
@@ -98,14 +97,13 @@ public class ExecutionService {
             templateRenderMap.put("customFields", renderedCustomFields);
         }
 
-        var executionVars = (Map<String, String>) runContext.getVariables().get("execution");
-        var isCurrentExecution = execution.getId().equals(executionVars.get("id"));
+        var isCurrentExecution = isCurrentExecution(runContext, execution.getId());
         var taskRuns = execution.getTaskRunList();
 
         final TaskRun lastTaskRun;
         var lastTaskRunState = execution.getTaskRunList().getLast().getState().getCurrent();
 
-        if (isCurrentExecution && State.Type.RUNNING.equals(lastTaskRunState)) {
+        if (isCurrentExecution) {
             lastTaskRun = taskRuns.getLast();
         } else {
             lastTaskRun = taskRuns.stream()
@@ -131,5 +129,10 @@ public class ExecutionService {
             runContext.getVariables().get("trigger")
         );
         return triggerVar.map(trigger -> ((Map<String, String>) trigger).get("state"));
+    }
+
+    private static boolean isCurrentExecution(RunContext runContext, String executionId) {
+        var executionVars = (Map<String, String>) runContext.getVariables().get("execution");
+        return executionId.equals(executionVars.get("id"));
     }
 }

--- a/src/main/java/io/kestra/plugin/notifications/services/ExecutionService.java
+++ b/src/main/java/io/kestra/plugin/notifications/services/ExecutionService.java
@@ -15,10 +15,7 @@ import io.kestra.core.utils.UriProvider;
 import io.kestra.plugin.notifications.ExecutionInterface;
 
 import java.time.Duration;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.NoSuchElementException;
-import java.util.Optional;
+import java.util.*;
 
 public class ExecutionService {
     public static Execution findExecution(RunContext runContext, Property<String> executionId) throws IllegalVariableEvaluationException, NoSuchElementException {
@@ -101,12 +98,24 @@ public class ExecutionService {
             templateRenderMap.put("customFields", renderedCustomFields);
         }
 
-        TaskRun lastTaskRun = execution.getTaskRunList().stream()
-            .filter(t -> (execution.hasFailed() ? State.Type.FAILED : State.Type.SUCCESS).equals(t.getState().getCurrent()))
-            .toList()
-            .getLast();
+        var executionVars = (Map<String, String>) runContext.getVariables().get("execution");
+        var isCurrentExecution = execution.getId().equals(executionVars.get("id"));
+        var taskRuns = execution.getTaskRunList();
 
-        templateRenderMap.put("firstFailed", State.Type.FAILED.equals(lastTaskRun.getState().getCurrent()) ? lastTaskRun : false);
+        final TaskRun lastTaskRun;
+        var lastTaskRunState = execution.getTaskRunList().getLast().getState().getCurrent();
+
+        if (isCurrentExecution && State.Type.RUNNING.equals(lastTaskRunState)) {
+            lastTaskRun = taskRuns.getLast();
+        } else {
+            lastTaskRun = taskRuns.stream()
+                .filter(t -> (execution.hasFailed() ? State.Type.FAILED : State.Type.SUCCESS)
+                    .equals(lastTaskRunState))
+                .toList()
+                .getLast();
+        }
+
+        templateRenderMap.put("firstFailed", State.Type.FAILED.equals((lastTaskRun).getState().getCurrent()) ? lastTaskRun : false);
         templateRenderMap.put("lastTask", lastTaskRun);
 
         return templateRenderMap;


### PR DESCRIPTION
Fixes `NoSuchElementException` when last task run has a state `RUNNING`, for the current execution.

fixes #226