### PR TITLE
fix(telegram): response deserialization error due to new property 'message_id'

### DIFF
--- a/src/main/java/io/kestra/plugin/notifications/telegram/TelegramBotApiService.java
+++ b/src/main/java/io/kestra/plugin/notifications/telegram/TelegramBotApiService.java
@@ -1,5 +1,7 @@
 package io.kestra.plugin.notifications.telegram;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.http.HttpRequest;
 import io.kestra.core.http.HttpResponse;
@@ -7,6 +9,9 @@ import io.kestra.core.http.client.HttpClient;
 import io.kestra.core.http.client.HttpClientException;
 import io.kestra.core.http.client.HttpClientResponseException;
 import io.micronaut.http.HttpStatus;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.net.URI;
 import java.util.Objects;
@@ -47,7 +52,27 @@ public class TelegramBotApiService {
     public record TelegramBotApiResponse(boolean ok, TelegramMessage result) {
     }
 
-    public record TelegramMessage(String chat_id, String text, String parse_mode) {
+    @Getter
+    @NoArgsConstructor
+    @EqualsAndHashCode
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class TelegramMessage {
+        @JsonProperty("chat_id")
+        private String chatId;
+
+        private String text;
+
+        @JsonProperty("parse_mode")
+        private String parseMode;
+
+        @JsonProperty("message_id")
+        private Integer messageId;
+
+        public TelegramMessage(String chatId, String text, String parseMode) {
+            this.chatId = chatId;
+            this.text = text;
+            this.parseMode = parseMode;
+        }
     }
 
     public static class ErrorSendingMessageException extends Exception {

--- a/src/test/java/io/kestra/plugin/notifications/telegram/TelegramExecutionTest.java
+++ b/src/test/java/io/kestra/plugin/notifications/telegram/TelegramExecutionTest.java
@@ -19,8 +19,7 @@ import java.util.concurrent.TimeoutException;
 
 import static io.kestra.core.tenant.TenantService.MAIN_TENANT;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.comparesEqualTo;
-import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.*;
 
 /**
  * This test will only test the main task, this allow you to send any input
@@ -57,9 +56,10 @@ class TelegramExecutionTest {
         );
 
         assertThat(FakeTelegramController.token, comparesEqualTo("token"));
-        assertThat(FakeTelegramController.message.chat_id(), comparesEqualTo("channel"));
-        assertThat(FakeTelegramController.message.text(), containsString("<io.kestra.tests telegram"));
-        assertThat(FakeTelegramController.message.text(), containsString("Failed on task `failed`"));
-        assertThat(FakeTelegramController.message.text(), containsString("Final task ID ➛ failed"));
+        assertThat(FakeTelegramController.message.getChatId(), comparesEqualTo("channel"));
+        assertThat(FakeTelegramController.message.getText(), containsString("<io.kestra.tests telegram"));
+        assertThat(FakeTelegramController.message.getText(), containsString("Failed on task `failed`"));
+        assertThat(FakeTelegramController.message.getText(), containsString("Final task ID ➛ failed"));
+        assertThat(FakeTelegramController.message.getMessageId(), is(nullValue()));
     }
 }


### PR DESCRIPTION
Fixes `UnrecognizedPropertyException` because of new property "message_id" field in the response.

- closes #231 