### PR TITLE
docs(slack): remove deprecated properties

### DIFF
--- a/src/main/java/io/kestra/plugin/notifications/slack/SlackExecution.java
+++ b/src/main/java/io/kestra/plugin/notifications/slack/SlackExecution.java
@@ -36,7 +36,6 @@ import java.util.Map;
                   - id: send_alert
                     type: io.kestra.plugin.notifications.slack.SlackExecution
                     url: "{{ secret('SLACK_WEBHOOK') }}" # format: https://hooks.slack.com/services/xzy/xyz/xyz
-                    channel: "#general"
                     executionId: "{{trigger.executionId}}"
 
                 triggers:
@@ -63,7 +62,6 @@ import java.util.Map;
                   - id: send_alert_to_rocket_chat
                     type: io.kestra.plugin.notifications.slack.SlackExecution
                     url: "{{ secret('ROCKET_CHAT_WEBHOOK') }}"
-                    channel: "#errors"
                     username: "Kestra TEST"
                     iconUrl: "https://avatars.githubusercontent.com/u/59033362?s=48"
                     executionId: "{{ trigger.executionId }}"

--- a/src/main/java/io/kestra/plugin/notifications/slack/SlackExecution.java
+++ b/src/main/java/io/kestra/plugin/notifications/slack/SlackExecution.java
@@ -62,6 +62,7 @@ import java.util.Map;
                   - id: send_alert_to_rocket_chat
                     type: io.kestra.plugin.notifications.slack.SlackExecution
                     url: "{{ secret('ROCKET_CHAT_WEBHOOK') }}"
+                    channel: "#errors"
                     username: "Kestra TEST"
                     iconUrl: "https://avatars.githubusercontent.com/u/59033362?s=48"
                     executionId: "{{ trigger.executionId }}"

--- a/src/main/java/io/kestra/plugin/notifications/slack/SlackIncomingWebhook.java
+++ b/src/main/java/io/kestra/plugin/notifications/slack/SlackIncomingWebhook.java
@@ -133,7 +133,7 @@ import java.net.URI;
                 """
         ),
         @Example(
-            title = "Send a [Rocket.Chat](https://www.rocket.chat/) message via [incoming webhook](https://docs.rocket.chat/docs/integrations#incoming-webhook-script).",
+            title = "Send a Rocket Chat message via [Slack incoming webhook](https://docs.rocket.chat/docs/integrations#incoming-webhook-script).",
             full = true,
             code = """
                 id: rocket_chat_notification

--- a/src/main/java/io/kestra/plugin/notifications/zulip/ZulipExecution.java
+++ b/src/main/java/io/kestra/plugin/notifications/zulip/ZulipExecution.java
@@ -21,7 +21,7 @@ import java.util.Map;
 @Schema(
     title = "Send a Zulip message with the execution information.",
     description = "The message will include a link to the execution page in the UI along with the execution ID, namespace, flow name, the start date, duration, and the final status of the execution. If failed, then the task that led to the failure is specified.\n\n" +
-    "Use this notification task only in a flow that has a [Flow trigger](https://kestra.io/docs/administrator-guide/monitoring#alerting). Don't use this notification task in `errors` tasks. Instead, for `errors` tasks, use the [ZulipIncomingWebhook](https://kestra.io/plugins/plugin-notifications/tasks/slack/io.kestra.plugin.notifications.slack.slackincomingwebhook) task."
+    "Use this notification task only in a flow that has a [Flow trigger](https://kestra.io/docs/administrator-guide/monitoring#alerting). Don't use this notification task in `errors` tasks. Instead, for `errors` tasks, use the [ZulipIncomingWebhook](https://kestra.io/plugins/plugin-notifications/zulip/io.kestra.plugin.notifications.zulip.zulipincomingwebhook) task."
 )
 @Plugin(
     examples = {


### PR DESCRIPTION
Remove `channel` property from examples as it is deprecated. Also clarify that Rocket.Chat uses the Slack Webhook standard (I think?).

Unclear if Rocket Chat still uses the deprecated properties though so leaving those for now.