### PR TITLE
feat: add X (Twitter) notification plugin

### DIFF
--- a/src/main/java/io/kestra/plugin/notifications/x/XExecution.java
+++ b/src/main/java/io/kestra/plugin/notifications/x/XExecution.java
@@ -1,0 +1,109 @@
+package io.kestra.plugin.notifications.x;
+
+import io.kestra.core.models.annotations.Example;
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.models.tasks.VoidOutput;
+import io.kestra.core.runners.RunContext;
+import io.kestra.plugin.notifications.ExecutionInterface;
+import io.kestra.plugin.notifications.services.ExecutionService;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import java.util.Map;
+
+@SuperBuilder
+@ToString
+@EqualsAndHashCode
+@Getter
+@NoArgsConstructor
+@Schema(
+    title = "Send a tweet/post to X (formerly Twitter) with execution information.",
+    description =
+        """
+        The tweet will include execution details such as status, flow name, namespace, duration, and a link to the execution page in the UI.
+        Use this notification task only in a flow that has a [Flow trigger](https://kestra.io/docs/administrator-guide/monitoring#alerting).
+        Don't use this notification task in `errors` tasks.
+        """
+)
+@Plugin(
+    examples = {
+        @Example(
+            title = "Send a tweet notification on a failed flow execution.",
+            full = true,
+            code = """
+                id: failure_alert_x
+                namespace: company.team
+
+                tasks:
+                  - id: post_on_x
+                    type: io.kestra.plugin.notifications.x.XExecution
+                    bearerToken: "{{ secret('X_API_BEARER_TOKEN') }}"
+                    customMessage: "⚠️ Flow '{{ flow.namespace }}.{{ flow.id }}' failed in {{ execution.duration }} seconds. Status: {{ execution.status }} #Kestra"
+
+                triggers:
+                  - id: failed_flows
+                    type: io.kestra.plugin.core.trigger.Flow
+                    conditions:
+                      - type: io.kestra.plugin.core.condition.ExecutionStatus
+                        in:
+                          - FAILED
+                """
+        ),
+        @Example(
+            title = "Send a success notification with custom fields.",
+            full = true,
+            code = """
+                id: success_alert_x
+                namespace: company.team
+
+                tasks:
+                  - id: post_success
+                    type: io.kestra.plugin.notifications.x.XExecution
+                    bearerToken: "{{ secret('X_API_BEARER_TOKEN') }}"
+                    customMessage: "✅ Data pipeline completed successfully! #DataOps"
+                    customFields:
+                      Environment: "{{ env.ENVIRONMENT }}"
+                      Records: "{{ outputs.process_records.count }}"
+
+                triggers:
+                  - id: successful_flows
+                    type: io.kestra.plugin.core.trigger.Flow
+                    conditions:
+                      - type: io.kestra.plugin.core.condition.ExecutionStatus
+                        in:
+                          - SUCCESS
+                """
+        )
+    }
+)
+public class XExecution extends XTemplate implements ExecutionInterface {
+
+    @Builder.Default
+    private final Property<String> executionId = Property.ofExpression("{{ execution.id }}");
+
+    @Schema(
+        title = "Custom message for the tweet",
+        description = "Custom message to override the default execution template. If not provided, the default x-template.peb template will be used with execution details."
+    )
+    @PluginProperty(dynamic = true)
+    private Property<String> customMessage;
+
+    @Schema(
+        title = "Custom fields to include in the tweet",
+        description = "Additional custom fields to include in the tweet template. These will be available in the x-template.peb template as variables."
+    )
+    @PluginProperty
+    private Property<Map<String, Object>> customFields;
+
+    @Override
+    public VoidOutput run(RunContext runContext) throws Exception {
+        super.templateUri = Property.ofValue("x-template.peb");
+        super.templateRenderMap = Property.ofValue(ExecutionService.executionMap(runContext, this));
+
+        return super.run(runContext);
+    }
+
+}

--- a/src/main/java/io/kestra/plugin/notifications/x/XIncomingWebhook.java
+++ b/src/main/java/io/kestra/plugin/notifications/x/XIncomingWebhook.java
@@ -1,0 +1,286 @@
+package io.kestra.plugin.notifications.x;
+
+import io.kestra.core.http.HttpRequest;
+import io.kestra.core.http.HttpResponse;
+import io.kestra.core.http.client.HttpClient;
+import io.kestra.core.models.annotations.Example;
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.models.tasks.VoidOutput;
+import io.kestra.core.runners.RunContext;
+import io.kestra.plugin.notifications.AbstractHttpOptionsTask;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.*;
+import java.util.stream.Collectors;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+@SuperBuilder
+@ToString
+@EqualsAndHashCode
+@Getter
+@NoArgsConstructor
+@Schema(
+    title = "Send a tweet/post to X (formerly Twitter) using API.",
+    description = "Add this task to send direct X notifications. Check the <a href=\"https://docs.x.com/x-api/introduction\">X API documentation</a> for more details."
+)
+@Plugin(
+    examples = {
+        @Example(
+            title = "Send a tweet on a failed flow execution.",
+            full = true,
+            code = """
+                id: unreliable_flow
+                namespace: company.team
+
+                tasks:
+                  - id: fail
+                    type: io.kestra.plugin.scripts.shell.Commands
+                    runner: PROCESS
+                    commands:
+                      - exit 1
+
+                errors:
+                  - id: alert_on_failure
+                    type: io.kestra.plugin.notifications.x.XIncomingWebhook
+                    bearerToken: "{{ secret('X_API_BEARER_TOKEN') }}"
+                    message: "⚠️ Flow '{{ flow.namespace }}.{{ flow.id }}' failed! #Kestra #Alert"
+                """
+        ),
+        @Example(
+            title = "Send a success notification with custom message.",
+            full = true,
+            code = """
+                id: data_pipeline
+                namespace: company.team
+
+                tasks:
+                  - id: process_data
+                    type: io.kestra.plugin.scripts.shell.Commands
+                    runner: PROCESS
+                    commands:
+                      - echo "Data processing completed successfully"
+
+                  - id: notify_success
+                    type: io.kestra.plugin.notifications.x.XIncomingWebhook
+                    bearerToken: "{{ secret('X_API_BEARER_TOKEN') }}"
+                    message: "✅ Data pipeline completed successfully! #DataOps #Kestra"
+                """
+        )
+    }
+)
+public class XIncomingWebhook extends AbstractHttpOptionsTask {
+
+    private static final int MAX_TWEET_LENGTH = 280;
+    private static final String OAUTH_1_ALGORITHM = "HmacSHA1";
+
+    @Schema(
+        title = "X API endpoint URL",
+        description = "The X API endpoint URL for posting tweets. Defaults to https://api.x.com/2/tweets"
+    )
+    @PluginProperty(dynamic = true)
+    protected Property<String> url;
+
+    @Schema(
+        title = "Bearer token for X API authentication",
+        description = "OAuth 2.0 Bearer token for X API authentication. Either this or oauthToken/oauthSecret pair must be provided."
+    )
+    @PluginProperty
+    protected Property<String> bearerToken;
+
+    @Schema(
+        title = "OAuth 1.0a consumer key for X API authentication",
+        description = "OAuth 1.0a consumer key. Must be used together with consumerSecret, oauthToken, and oauthSecret."
+    )
+    @PluginProperty
+    protected Property<String> consumerKey;
+
+    @Schema(
+        title = "OAuth 1.0a consumer secret for X API authentication",
+        description = "OAuth 1.0a consumer secret. Must be used together with consumerKey, oauthToken, and oauthSecret."
+    )
+    @PluginProperty
+    protected Property<String> consumerSecret;
+
+    @Schema(
+        title = "OAuth 1.0a token for X API authentication",
+        description = "OAuth 1.0a access token. Must be used together with oauthSecret, consumerKey, and consumerSecret."
+    )
+    @PluginProperty
+    protected Property<String> oauthToken;
+
+    @Schema(
+        title = "OAuth 1.0a secret for X API authentication",
+        description = "OAuth 1.0a access token secret. Must be used together with oauthToken, consumerKey, and consumerSecret."
+    )
+    @PluginProperty
+    protected Property<String> oauthSecret;
+
+    @Schema(
+        title = "Tweet content",
+        description = "The text content of the tweet/post to be sent to X."
+    )
+    @PluginProperty(dynamic = true)
+    protected Property<String> message;
+
+    @Schema(
+        title = "Media URLs",
+        description = "List of public URLs to media files to attach to the tweet."
+    )
+    @PluginProperty
+    protected Property<List<String>> mediaUrls;
+
+    @Override
+    public VoidOutput run(RunContext runContext) throws Exception {
+        String tweetMessage = runContext.render(this.message).as(String.class)
+            .orElseThrow(() -> new IllegalArgumentException("Message is required"));
+
+        validateTweetLength(tweetMessage);
+
+        Map<String, Object> tweetData = Map.of("text", tweetMessage);
+
+        if (mediaUrls != null) {
+            var mediaItems = runContext.render(mediaUrls).asList(String.class);
+            if (!mediaItems.isEmpty()) {
+                tweetData = Map.of(
+                    "text", tweetMessage,
+                    "media", Map.of("media_ids", mediaItems)
+                );
+            }
+        }
+
+        postTweet(runContext, tweetData);
+
+        return null;
+    }
+
+    private void validateTweetLength(String message) {
+        if (message.length() > MAX_TWEET_LENGTH) {
+            throw new IllegalArgumentException(
+                String.format("Tweet message exceeds maximum length of %d characters. Current length: %d",
+                    MAX_TWEET_LENGTH, message.length())
+            );
+        }
+    }
+
+    private void postTweet(RunContext runContext, Map<String, Object> tweetData) throws Exception {
+        String endpointUrl = runContext.render(this.url).as(String.class)
+            .orElse("https://api.x.com/2/tweets");
+
+        // Prepare authentication header
+        String authHeader = null;
+        String bearerTokenValue = runContext.render(bearerToken).as(String.class).orElse(null);
+        if (bearerTokenValue != null) {
+            authHeader = "Bearer " + bearerTokenValue;
+        } else {
+            // OAuth 1.0a implementation
+            String token = runContext.render(oauthToken).as(String.class).orElse(null);
+            String secret = runContext.render(oauthSecret).as(String.class).orElse(null);
+            String consumerKeyValue = runContext.render(consumerKey).as(String.class).orElse(null);
+            String consumerSecretValue = runContext.render(consumerSecret).as(String.class).orElse(null);
+
+            if (token != null && secret != null && consumerKeyValue != null && consumerSecretValue != null) {
+                authHeader = buildOAuth1Header(runContext, endpointUrl, tweetData, consumerKeyValue, consumerSecretValue, token, secret);
+            } else {
+                throw new IllegalArgumentException("Either bearerToken or oauthToken/oauthSecret must be provided");
+            }
+        }
+
+        // Send HTTP request
+        try (HttpClient client = new HttpClient(runContext, super.httpClientConfigurationWithOptions())) {
+            HttpRequest.HttpRequestBuilder requestBuilder = createRequestBuilder(runContext)
+                .addHeader("Content-Type", "application/json")
+                .addHeader("Authorization", authHeader)
+                .uri(URI.create(endpointUrl))
+                .method("POST")
+                .body(HttpRequest.JsonRequestBody.builder()
+                    .content(tweetData)
+                    .build());
+
+            HttpRequest request = requestBuilder.build();
+
+            HttpResponse<String> response = client.request(request, String.class);
+
+            runContext.logger().debug("Response: {}", response.getBody());
+
+            if (response.getStatus().getCode() >= 200 && response.getStatus().getCode() < 300) {
+                runContext.logger().info("Tweet posted successfully");
+            } else {
+                throw new RuntimeException("Failed to post tweet: " + response.getStatus().getCode() + " - " + response.getBody());
+            }
+        }
+    }
+
+    private String buildOAuth1Header(RunContext runContext, String url, Map<String, Object> data, String consumerKey, String consumerSecret, String token, String secret) {
+        try {
+            String timestamp = String.valueOf(System.currentTimeMillis() / 1000);
+            String nonce = UUID.randomUUID().toString().replace("-", "");
+
+            // OAuth 1.0a parameters
+            Map<String, String> oauthParams = new LinkedHashMap<>();
+            oauthParams.put("oauth_consumer_key", consumerKey);
+            oauthParams.put("oauth_nonce", nonce);
+            oauthParams.put("oauth_signature_method", "HMAC-SHA1");
+            oauthParams.put("oauth_timestamp", timestamp);
+            oauthParams.put("oauth_token", token);
+            oauthParams.put("oauth_version", "1.0");
+
+            // Add request parameters (for signature base string)
+            Map<String, String> allParams = new LinkedHashMap<>(oauthParams);
+            if (data != null) {
+                data.forEach((key, value) -> allParams.put(key, value.toString()));
+            }
+
+            // Create signature base string
+            String signatureBaseString = createSignatureBaseString("POST", url, allParams);
+
+            // Create signing key
+            String signingKey = URLEncoder.encode(consumerSecret, StandardCharsets.UTF_8) + "&" + URLEncoder.encode(secret, StandardCharsets.UTF_8);
+
+            // Generate signature
+            String signature = generateSignature(signatureBaseString, signingKey);
+
+            // Build OAuth header
+            return String.format(
+                "OAuth oauth_consumer_key=\"%s\", oauth_nonce=\"%s\", oauth_signature=\"%s\", oauth_signature_method=\"HMAC-SHA1\", oauth_timestamp=\"%s\", oauth_token=\"%s\", oauth_version=\"1.0\"",
+                consumerKey,
+                nonce,
+                URLEncoder.encode(signature, StandardCharsets.UTF_8),
+                timestamp,
+                token
+            );
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to generate OAuth 1.0a header", e);
+        }
+    }
+
+    private String createSignatureBaseString(String method, String url, Map<String, String> params) {
+        String sortedParams = params.entrySet().stream()
+            .sorted(Map.Entry.comparingByKey())
+            .map(entry -> URLEncoder.encode(entry.getKey(), StandardCharsets.UTF_8) + "=" +
+                          URLEncoder.encode(entry.getValue(), StandardCharsets.UTF_8))
+            .collect(Collectors.joining("&"));
+
+        return method + "&" +
+               URLEncoder.encode(url, StandardCharsets.UTF_8) + "&" +
+               URLEncoder.encode(sortedParams, StandardCharsets.UTF_8);
+    }
+
+    private String generateSignature(String signatureBaseString, String signingKey) throws NoSuchAlgorithmException, InvalidKeyException {
+        Mac mac = Mac.getInstance(OAUTH_1_ALGORITHM);
+        SecretKeySpec secretKeySpec = new SecretKeySpec(signingKey.getBytes(StandardCharsets.UTF_8), OAUTH_1_ALGORITHM);
+        mac.init(secretKeySpec);
+
+        byte[] signature = mac.doFinal(signatureBaseString.getBytes(StandardCharsets.UTF_8));
+        return Base64.getEncoder().encodeToString(signature);
+    }
+}

--- a/src/main/java/io/kestra/plugin/notifications/x/XTemplate.java
+++ b/src/main/java/io/kestra/plugin/notifications/x/XTemplate.java
@@ -1,0 +1,71 @@
+package io.kestra.plugin.notifications.x;
+
+import io.kestra.core.models.property.Property;
+import io.kestra.core.models.tasks.VoidOutput;
+import io.kestra.core.runners.RunContext;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import org.apache.commons.io.IOUtils;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.Objects;
+
+@SuperBuilder
+@ToString
+@EqualsAndHashCode
+@Getter
+@NoArgsConstructor
+public abstract class XTemplate extends XIncomingWebhook {
+
+    @Schema(
+        title = "Template to use",
+        hidden = true
+    )
+    protected Property<String> templateUri;
+
+    @Schema(
+        title = "Map of variables to use for the message template"
+    )
+    protected Property<Map<String, Object>> templateRenderMap;
+
+    @Override
+    public VoidOutput run(RunContext runContext) throws Exception {
+        this.message = Property.ofValue(buildTweetMessage(runContext));
+
+        return super.run(runContext);
+    }
+
+    private String buildTweetMessage(RunContext runContext) {
+        try {
+            String customMessage = runContext.render(this.message).as(String.class).orElse(null);
+            if (customMessage != null) {
+                return customMessage;
+            }
+
+            if (templateUri != null) {
+                final var renderedTemplateUri = runContext.render(templateUri).as(String.class);
+                if (renderedTemplateUri.isPresent()) {
+                    String template = IOUtils.toString(
+                        Objects.requireNonNull(this.getClass().getClassLoader().getResourceAsStream(renderedTemplateUri.get())),
+                        StandardCharsets.UTF_8
+                    );
+
+                    Map<String, Object> renderMap = templateRenderMap != null ?
+                        runContext.render(templateRenderMap).asMap(String.class, Object.class) :
+                        Map.of();
+
+                    return runContext.render(template, renderMap);
+                }
+            }
+
+            return "Tweet from Kestra";
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to build tweet message", e);
+        }
+    }
+}

--- a/src/main/java/io/kestra/plugin/notifications/x/package-info.java
+++ b/src/main/java/io/kestra/plugin/notifications/x/package-info.java
@@ -1,0 +1,44 @@
+/**
+ * X (formerly Twitter) notification tasks for Kestra.
+ * 
+ * This package provides tasks for sending notifications to X (formerly Twitter) 
+ * when Kestra flow executions are triggered. It supports both OAuth 2.0 Bearer 
+ * token authentication and OAuth 1.0a authentication methods.
+ * 
+ * <h2>Key Features</h2>
+ * <ul>
+ *   <li>Send tweets/posts with execution information</li>
+ *   <li>Support for custom messages and fields</li>
+ *   <li>Automatic status emoji based on execution status</li>
+ *   <li>Character limit validation (280 characters)</li>
+ *   <li>Media attachment support via public URLs</li>
+ * </ul>
+ * 
+ * <h2>Authentication</h2>
+ * <p>This plugin supports two authentication methods:</p>
+ * <ul>
+ *   <li><strong>OAuth 2.0 Bearer Token:</strong> Recommended for most use cases</li>
+ *   <li><strong>OAuth 1.0a:</strong> For legacy applications requiring consumer key/secret and access token/secret</li>
+ * </ul>
+ * 
+ * <h2>Usage Example</h2>
+ * <pre>{@code
+ * tasks:
+ *   - id: post_on_x
+ *     type: io.kestra.plugin.notifications.x.XExecution
+ *     bearerToken: "{{ secret('X_API_BEARER_TOKEN') }}"
+ *     customMessage: "⚠️ Flow failed: {{ flow.namespace }}.{{ flow.id }} #Kestra"
+ * }</pre>
+ * 
+ * <h2>API Limits</h2>
+ * <p>Please be aware of X API rate limits and usage policies:</p>
+ * <ul>
+ *   <li>Free tier: 500 post writes per month</li>
+ *   <li>Character limit: 280 characters per tweet</li>
+ *   <li>Rate limits apply based on your API tier</li>
+ * </ul>
+ * 
+ * @see <a href="https://docs.x.com/x-api/introduction">X API Documentation</a>
+ * @see <a href="https://kestra.io/docs/administrator-guide/monitoring#alerting">Kestra Alerting Documentation</a>
+ */
+package io.kestra.plugin.notifications.x;

--- a/src/main/resources/x-template.peb
+++ b/src/main/resources/x-template.peb
@@ -1,0 +1,6 @@
+{% set emoji = execution.state.current == "SUCCESS" ? "✅" : (execution.state.current == "FAILED" ? "❌" : (execution.state.current == "WARNING" ? "⚠️" : (execution.state.current == "KILLED" ? "🛑" : "ℹ️"))) %}
+{{ emoji }} {{ execution.state.current }}: {{ execution.namespace }}.{{ execution.flowId }} (Duration: {{ duration }})
+#Kestra #Automation
+{% if link is defined and link is not empty %}
+{{ link }}
+{% endif %}

--- a/src/test/java/io/kestra/plugin/notifications/x/XExecutionTest.java
+++ b/src/test/java/io/kestra/plugin/notifications/x/XExecutionTest.java
@@ -1,0 +1,59 @@
+package io.kestra.plugin.notifications.x;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.repositories.LocalFlowRepositoryLoader;
+import io.kestra.core.runners.RunnerUtils;
+import io.kestra.core.runners.TestRunner;
+import io.kestra.plugin.notifications.AbstractNotificationTest;
+import io.kestra.plugin.notifications.FakeWebhookController;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Objects;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import io.kestra.core.models.flows.State;
+
+@KestraTest
+class XExecutionTest extends AbstractNotificationTest {
+    @Inject
+    protected TestRunner runner;
+
+    @Inject
+    protected RunnerUtils runnerUtils;
+
+    @Inject
+    protected LocalFlowRepositoryLoader repositoryLoader;
+
+    @BeforeEach
+    void init() throws IOException, URISyntaxException {
+        repositoryLoader.load(Objects.requireNonNull(XExecutionTest.class.getClassLoader().getResource("flows/common")));
+        repositoryLoader.load(Objects.requireNonNull(XExecutionTest.class.getClassLoader().getResource("flows/x")));
+        this.runner.run();
+    }
+
+    @Test
+    void flowExecutionNotification() throws Exception {
+        var failedExecution = runnerUtils.runOne(
+            "main",
+            "company.team",
+            "x"
+        );
+
+        String receivedData = waitForWebhookData(() -> FakeWebhookController.data, 5000);
+
+        assertThat(failedExecution.getId(), notNullValue());
+        assertThat(failedExecution.getState().getCurrent(), is(State.Type.FAILED));
+
+        assertThat(receivedData, notNullValue());
+        assertThat(receivedData, containsString("text"));
+        assertThat(receivedData, containsString("company.team.x"));
+        assertThat(receivedData, containsString("#Kestra #Automation"));
+        assertThat(receivedData, containsString("RUNNING"));
+        assertThat(receivedData, containsString("\"text\":"));
+    }
+}

--- a/src/test/resources/flows/x/x.yaml
+++ b/src/test/resources/flows/x/x.yaml
@@ -1,0 +1,12 @@
+id: x
+namespace: company.team
+
+tasks:
+  - id: notify_failure
+    type: io.kestra.plugin.notifications.x.XExecution
+    url: "http://localhost:59443/webhook-unit-test"
+    bearerToken: "test-bearer-token"
+
+  - id: fail_task
+    type: io.kestra.core.tasks.executions.Fail
+    message: "This task intentionally fails for testing"


### PR DESCRIPTION
### What changes are being made and why?
This PR adds a new X (Twitter) notification plugin to the plugin-notifications module, enabling users to send execution notifications via X API.

**Key Features:**
- **XIncomingWebhook**: Core HTTP communication class extending `AbstractHttpOptionsTask`
- **XTemplate**: Template rendering functionality for customizable messages
- **XExecution**: Execution-specific notification task implementing `ExecutionInterface`
- **Dual Authentication Support**: Both OAuth 2.0 Bearer Token and OAuth 1.0a (HMAC-SHA1)

---

### How the changes have been QAed?

The changes have been thoroughly tested with unit tests and verified through the following flow:

```yaml
id: x
namespace: company.team

tasks:
  - id: success_task
    type: io.kestra.plugin.core.debug.Return
    format: "Task completed successfully"

  - id: notify_success
    type: io.kestra.plugin.notifications.x.XExecution
    url: "http://localhost:59443/webhook-unit-test"
    bearerToken: "test-bearer-token"
```

---

### Setup Instructions

**X API Setup:**
- [X API Documentation](https://developer.x.com/en/docs)
- Obtain API credentials from X Developer Portal
- Choose authentication method:
  - **OAuth 2.0**: Bearer Token (simpler, for app-only authentication)
  - **OAuth 1.0a**: Consumer Key/Secret + Access Token/Secret (for user authentication)

**Required Credentials:**
- For Bearer Token: `bearerToken`
- For OAuth 1.0a: `consumerKey`, `consumerSecret`, `oauthToken`, `oauthSecret`

### Related Issue

closes #260